### PR TITLE
Initialize database search indexes

### DIFF
--- a/backend/my_app/database.py
+++ b/backend/my_app/database.py
@@ -290,7 +290,8 @@ async def create_additional_indexes():
             # Use connection with autocommit for CONCURRENT operations
             async with async_engine.connect() as conn:
                 # Set autocommit mode
-                await conn.execution_options(autocommit=True).execute(text(index_sql))
+                conn_with_options = await conn.execution_options(autocommit=True)
+                await conn_with_options.execute(text(index_sql))
                 logger.info(f"✅ Created concurrent index: {index_name}")
                 
         except Exception as e:

--- a/backend/my_app/routers/admin.py
+++ b/backend/my_app/routers/admin.py
@@ -178,8 +178,8 @@ async def perform_database_maintenance(
                 # These commands can't run in a transaction block
                 # Get the underlying connection
                 connection = await db.connection()
-                await connection.execution_options(isolation_level="AUTOCOMMIT")
-                await db.execute(text(db_action.upper()))
+                connection_with_options = await connection.execution_options(isolation_level="AUTOCOMMIT")
+                await connection_with_options.execute(text(db_action.upper()))
                 logger.info(f"Database maintenance '{db_action}' completed successfully.")
             else:
                 logger.warning(f"Invalid maintenance action: {db_action}")


### PR DESCRIPTION
Fix `RuntimeWarning` and `AttributeError` by correctly awaiting `AsyncConnection.execution_options` in SQLAlchemy.

The `AsyncConnection.execution_options()` method returns an awaitable coroutine. Previously, subsequent methods like `.execute()` were called directly on this coroutine instead of on its awaited result, leading to runtime warnings and incorrect behavior during concurrent index creation and admin database operations.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ff951173-06c7-4732-a62a-c6b280739921) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ff951173-06c7-4732-a62a-c6b280739921)