### PR TITLE
Handle concurrent index creation warning

### DIFF
--- a/backend/my_app/database.py
+++ b/backend/my_app/database.py
@@ -289,8 +289,8 @@ async def create_additional_indexes():
             
             # Use connection with autocommit for CONCURRENT operations
             async with async_engine.connect() as conn:
-                # Set autocommit mode
-                conn_with_options = await conn.execution_options(autocommit=True)
+                # Set autocommit mode for PostgreSQL
+                conn_with_options = await conn.execution_options(isolation_level="AUTOCOMMIT")
                 await conn_with_options.execute(text(index_sql))
                 logger.info(f"✅ Created concurrent index: {index_name}")
                 

--- a/backend/test_db_init.py
+++ b/backend/test_db_init.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Test script to verify database initialization works correctly
+"""
+import asyncio
+import sys
+import os
+from pathlib import Path
+
+# Add the my_app directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'my_app'))
+
+from database import init_database, check_database_connection
+import logging
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+async def test_database_initialization():
+    """Test database initialization including concurrent indexes"""
+    try:
+        logger.info("🧪 Testing database initialization...")
+        
+        # Test basic connection first
+        logger.info("📡 Testing database connection...")
+        if not await check_database_connection():
+            logger.error("❌ Database connection failed")
+            return False
+        logger.info("✅ Database connection successful")
+        
+        # Test full initialization
+        logger.info("🏗️  Testing database initialization...")
+        await init_database()
+        logger.info("✅ Database initialization completed successfully")
+        
+        return True
+        
+    except Exception as e:
+        logger.error(f"❌ Database initialization test failed: {e}")
+        return False
+
+async def main():
+    """Main test function"""
+    logger.info("🚀 Starting database initialization test...")
+    
+    success = await test_database_initialization()
+    
+    if success:
+        logger.info("🎉 All tests passed!")
+        sys.exit(0)
+    else:
+        logger.error("💥 Tests failed!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Fix PostgreSQL concurrent index creation warning and add a verification test script.

The error `CREATE INDEX CONCURRENTLY cannot run inside a transaction block` occurred because `autocommit=True` is not the correct way to achieve autocommit behavior with PostgreSQL and the asyncpg driver. The fix involves using `isolation_level="AUTOCOMMIT"` which correctly runs the `CREATE INDEX CONCURRENTLY` command outside of a transaction, as required by PostgreSQL. This resolves the warning and ensures proper index creation for improved search performance. A new test script (`test_db_init.py`) is included to verify the fix.

---

[Open in Web](https://www.cursor.com/agents?id=bc-498905c3-2bbf-4a3b-8295-2874ee77067c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-498905c3-2bbf-4a3b-8295-2874ee77067c)