### PR TITLE
Initialize fastapi app and sqladmin

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ fastapi_mail
 python-dateutil==2.8.2
 psutil==5.9.8
 openpyxl==3.1.2
+pytz==2023.3


### PR DESCRIPTION
Add `pytz` dependency to `requirements.txt` to resolve `No module named 'pytz'` error preventing SQLAdmin views from loading.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0a941fe9-d16c-4f43-b028-fc0250723aa6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0a941fe9-d16c-4f43-b028-fc0250723aa6)