### PR TITLE
Fix admin view relative import error

### DIFF
--- a/backend/my_app/admin.py
+++ b/backend/my_app/admin.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm.exc import DetachedInstanceError
 from datetime import datetime, timedelta
 import pytz
 import logging
-from .models import (
+from models import (
     User, Property, Room, Machine, Topic, Procedure, PMSchedule, PMExecution,
     Issue, Inspection, PMFile, UserPropertyAccess,
     UserRole, FrequencyType, PMStatus, IssueStatus, IssuePriority,

--- a/backend/my_app/admin_debug.py
+++ b/backend/my_app/admin_debug.py
@@ -5,7 +5,7 @@ Debug admin panel - minimal version to test if admin works
 import logging
 from sqladmin import ModelView
 from markupsafe import Markup
-from .models import User, Property, Room, Machine
+from models import User, Property, Room, Machine
 
 # Set up logging
 logging.basicConfig(level=logging.DEBUG)

--- a/backend/my_app/dependencies.py
+++ b/backend/my_app/dependencies.py
@@ -6,9 +6,9 @@ from jose import jwt, JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy import select
-from . import crud, models, schemas
-from .database import SessionLocal
-from .security import SECRET_KEY, ALGORITHM
+import crud, models, schemas
+from database import SessionLocal
+from security import SECRET_KEY, ALGORITHM
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/users/token")
 oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="/api/v1/users/token", auto_error=False)

--- a/backend/my_app/init_required_data.py
+++ b/backend/my_app/init_required_data.py
@@ -1,9 +1,9 @@
 # backend/init_required_data.py
 import asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
-from my_app.database import SessionLocal
-from my_app.models import Property, User, UserProfile
-from my_app.security import get_password_hash
+from database import SessionLocal
+from models import Property, User, UserProfile
+from security import get_password_hash
 
 async def init_required_data():
     async with SessionLocal() as db:

--- a/backend/my_app/login_admin.py
+++ b/backend/my_app/login_admin.py
@@ -8,9 +8,9 @@ from sqladmin.authentication import AuthenticationBackend
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
-from .database import sync_engine
-from .models import User, UserRole
-from .security import verify_password, create_access_token, SECRET_KEY, ALGORITHM
+from database import sync_engine
+from models import User, UserRole
+from security import verify_password, create_access_token, SECRET_KEY, ALGORITHM
 from jose import jwt, JWTError
 
 class AdminAuthBackend(AuthenticationBackend):

--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -10,7 +10,7 @@ import enum
 from datetime import datetime
 
 # Import Base from database with relative import
-from my_app.database import Base  # ← Changed from "database" to ".database"
+from database import Base
 
 # Enums
 class UserRole(str, enum.Enum):

--- a/backend/my_app/security.py
+++ b/backend/my_app/security.py
@@ -93,7 +93,7 @@ async def get_current_user(token: str, db: AsyncSession) -> 'models.User':
     )
     
     # Check if token is blacklisted
-    from .routers.auth import TOKEN_BLACKLIST
+    from routers.auth import TOKEN_BLACKLIST
     if token in TOKEN_BLACKLIST:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/my_app/seed_data.py
+++ b/backend/my_app/seed_data.py
@@ -1,7 +1,7 @@
 import json
 from sqlalchemy.orm import Session
-from my_app.database import SessionLocal, sync_engine
-from my_app.models import Base, Room, Property
+from database import SessionLocal, sync_engine
+from models import Base, Room, Property
 from datetime import datetime
 
 # JSON data provided by the user


### PR DESCRIPTION
Refactor imports within `my_app` to use absolute paths to resolve relative import errors.

The error "attempted relative import with no known parent package" occurred because modules within the `my_app` package were using relative imports (e.g., `from .models import`) or imports prefixed with `my_app.` (e.g., `from my_app.database import`) while being executed in a context where they were treated as standalone scripts rather than part of a package. This PR updates all such imports to use absolute paths (e.g., `from models import`, `from database import`) to ensure correct module resolution.

---

[Open in Web](https://www.cursor.com/agents?id=bc-015e0828-f4e8-4ca1-93da-4ea725b3f8df) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-015e0828-f4e8-4ca1-93da-4ea725b3f8df)