### PR TITLE
Fix relative import errors in backend

### DIFF
--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -9,8 +9,8 @@ from sqlalchemy.sql import func
 import enum
 from datetime import datetime
 
-# Import Base from database with relative import
-from .database import Base
+# Import Base from database with absolute import
+from database import Base
 
 # Enums
 class UserRole(str, enum.Enum):

--- a/backend/my_app/routers/__init__.py
+++ b/backend/my_app/routers/__init__.py
@@ -3,18 +3,18 @@
 Router package for PM System API init.py
 """
 from fastapi import APIRouter
-from .auth import router as auth_router
-from .users import router as users_router
-from .properties import router as properties_router
-from .machines import router as machines_router
-from .pm_schedules import router as pm_schedules_router
-from .pm_executions import router as pm_executions_router
-from .issues import router as issues_router
-from .inspections import router as inspections_router
-from .files import router as files_router
-from .dashboard import router as dashboard_router
-from .search import router as search_router
-from .admin import router as admin_router
+from routers.auth import router as auth_router
+from routers.users import router as users_router
+from routers.properties import router as properties_router
+from routers.machines import router as machines_router
+from routers.pm_schedules import router as pm_schedules_router
+from routers.pm_executions import router as pm_executions_router
+from routers.issues import router as issues_router
+from routers.inspections import router as inspections_router
+from routers.files import router as files_router
+from routers.dashboard import router as dashboard_router
+from routers.search import router as search_router
+from routers.admin import router as admin_router
 
 # Create main API router
 api_router = APIRouter(prefix="/api/v1")

--- a/backend/my_app/routers/admin.py
+++ b/backend/my_app/routers/admin.py
@@ -28,7 +28,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 # --- Configuration ---
 router = APIRouter()

--- a/backend/my_app/routers/dashboard.py
+++ b/backend/my_app/routers/dashboard.py
@@ -14,7 +14,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/files.py
+++ b/backend/my_app/routers/files.py
@@ -18,7 +18,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/inspections.py
+++ b/backend/my_app/routers/inspections.py
@@ -14,7 +14,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/issues.py
+++ b/backend/my_app/routers/issues.py
@@ -14,7 +14,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/machines.py
+++ b/backend/my_app/routers/machines.py
@@ -16,7 +16,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/pm_executions.py
+++ b/backend/my_app/routers/pm_executions.py
@@ -13,7 +13,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/pm_schedules.py
+++ b/backend/my_app/routers/pm_schedules.py
@@ -14,7 +14,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/properties.py
+++ b/backend/my_app/routers/properties.py
@@ -16,7 +16,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/routers/search.py
+++ b/backend/my_app/routers/search.py
@@ -10,7 +10,7 @@ from models import User
 from schemas import SearchRequest, SearchResult, PaginationParams
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user
+from routers.auth import get_current_active_user
 
 router = APIRouter()
 

--- a/backend/my_app/routers/users.py
+++ b/backend/my_app/routers/users.py
@@ -13,7 +13,7 @@ from schemas import (
 )
 import crud
 from crud import CRUDError
-from .auth import get_current_active_user, require_role
+from routers.auth import get_current_active_user, require_role
 
 router = APIRouter()
 

--- a/backend/my_app/security.py
+++ b/backend/my_app/security.py
@@ -13,13 +13,13 @@ from fastapi import HTTPException, status, Depends
 from fastapi.security import OAuth2PasswordBearer
 
 # Import models to fix the NameError
-from . import models
+import models
 
 # --- FIX IS HERE ---
 # This special block is only 'True' for type checkers, not when the app is running.
 # This breaks the import loop.
 if TYPE_CHECKING:
-    from . import schemas
+    import schemas
 
 # Password Hashing Setup
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/backend/my_app/utils/helpers.py
+++ b/backend/my_app/utils/helpers.py
@@ -1,6 +1,6 @@
 # File: backend/my_app/utils/helpers.py
 import re
-from ..models import Frequency
+from models import Frequency
 
 def parse_frequency_and_duration(input_str: str) -> tuple[str | None, str | None]:
     if not input_str:

--- a/backend/my_app/utils/procedure_planning.py
+++ b/backend/my_app/utils/procedure_planning.py
@@ -4,7 +4,7 @@
 # ==============================================================================
 from datetime import date, datetime, timedelta
 from typing import List, Dict, Optional
-from .. import models, schemas
+import models, schemas
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 


### PR DESCRIPTION
Convert relative Python imports to absolute imports to resolve `ImportError: attempted relative import with no known parent package`.

The error occurred because the application, when run via uvicorn in the Docker environment, was not treating modules as part of a package hierarchy, causing relative imports (e.g., `from .database import Base`) to fail. By converting these to absolute imports (e.g., `from database import Base` or `from my_app.database import Base`), and ensuring the `my_app` directory is on the Python path, modules can be correctly located and imported.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e369a261-b899-4d0e-ad71-37bd2e9ca8f7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e369a261-b899-4d0e-ad71-37bd2e9ca8f7)