### PR TITLE
Fix undefined 'Any' in admin views

### DIFF
--- a/backend/my_app/admin.py
+++ b/backend/my_app/admin.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import pytz
 import logging
 from contextlib import asynccontextmanager
+from typing import Any
 from database import get_db
 from models import (
     User, Property, Room, Machine, Topic, Procedure, PMSchedule, PMExecution,


### PR DESCRIPTION
Add missing `Any` import to `admin.py` to resolve `name 'Any' is not defined` error.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3f1132b4-e84e-4660-87a8-08fe241de6e8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3f1132b4-e84e-4660-87a8-08fe241de6e8)