### PR TITLE
Define user properties many to many relationship

### DIFF
--- a/SCHEMA_DOCUMENTATION.md
+++ b/SCHEMA_DOCUMENTATION.md
@@ -1,0 +1,287 @@
+# Schema Model Documentation: User Many-to-Many Models Properties
+
+## Overview
+
+This document describes the database schema for the PM (Preventive Maintenance) System, focusing on the many-to-many relationships between users and properties, as well as the newly added machine-procedure associations.
+
+## Database Schema Architecture
+
+### Core Entity Hierarchy
+
+```
+Property
+├── Room (1:many)
+    ├── Machine (1:many)
+        ├── PMSchedule (1:many)
+        ├── Issue (1:many)
+        └── Inspection (1:many)
+```
+
+### User Access Control
+
+```
+User ↔ Property (many:many via UserPropertyAccess)
+User → PMSchedule (1:many as responsible_user)
+User → PMExecution (1:many as executor)
+User → Issue (1:many as reporter)
+User → Issue (1:many as assignee)
+User → Inspection (1:many as inspector)
+```
+
+## Many-to-Many Relationships
+
+### 1. User ↔ Property (via UserPropertyAccess)
+
+**Purpose**: Controls which users have access to which properties and their access levels.
+
+**Table**: `user_property_access`
+
+**Columns**:
+- `user_id` (PK, FK to users.id)
+- `property_id` (PK, FK to properties.id)
+- `access_level` (ENUM: READ_ONLY, FULL_ACCESS, SUPERVISOR, ADMIN)
+- `granted_at` (DATETIME)
+- `expires_at` (DATETIME, nullable)
+
+**Model Definition**:
+```python
+class UserPropertyAccess(Base):
+    __tablename__ = "user_property_access"
+    
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True, index=True)
+    property_id = Column(Integer, ForeignKey("properties.id"), primary_key=True, index=True)
+    access_level = Column(Enum(AccessLevel), nullable=False, index=True)
+    granted_at = Column(DateTime, server_default=func.now(), index=True)
+    expires_at = Column(DateTime, index=True)
+    
+    # Relationships
+    user = relationship("User", back_populates="property_access", lazy="selectin")
+    property = relationship("Property", back_populates="user_access", lazy="selectin")
+```
+
+**Access Levels**:
+- `READ_ONLY`: Can view property data
+- `FULL_ACCESS`: Can create/edit work orders and schedules
+- `SUPERVISOR`: Can assign tasks and approve work
+- `ADMIN`: Full administrative access to property
+
+**Use Cases**:
+- Multi-tenant system where users only access specific properties
+- Role-based access control at the property level
+- Time-limited access grants (via expires_at)
+- Audit trail of access grants (via granted_at)
+
+### 2. Machine ↔ Procedure (via machine_procedure_association)
+
+**Purpose**: Defines which maintenance procedures can be performed on which machines.
+
+**Table**: `machine_procedure_association`
+
+**Columns**:
+- `machine_id` (PK, FK to machines.id)
+- `procedure_id` (PK, FK to procedures.id)
+- `created_at` (DATETIME)
+
+**Model Definition**:
+```python
+# Association table
+machine_procedure_association = Table(
+    'machine_procedure_association',
+    Base.metadata,
+    Column('machine_id', Integer, ForeignKey('machines.id'), primary_key=True),
+    Column('procedure_id', Integer, ForeignKey('procedures.id'), primary_key=True),
+    Column('created_at', DateTime, server_default=func.now()),
+    Index('idx_machine_procedure_machine', 'machine_id'),
+    Index('idx_machine_procedure_procedure', 'procedure_id'),
+)
+
+# Updated Machine model
+class Machine(Base):
+    # ... existing columns ...
+    procedures = relationship("Procedure", secondary=machine_procedure_association, back_populates="machines", lazy="selectin")
+
+# Updated Procedure model  
+class Procedure(Base):
+    # ... existing columns ...
+    machines = relationship("Machine", secondary=machine_procedure_association, back_populates="procedures", lazy="selectin")
+```
+
+**Use Cases**:
+- Validation: Only allow PM schedules for valid machine-procedure combinations
+- Equipment-specific procedures (e.g., HVAC procedures only for HVAC machines)
+- Compliance requirements (certain machines require specific procedures)
+- Work order validation
+
+## Schema Relationships (Pydantic)
+
+### User Property Access Schemas
+
+```python
+class UserPropertyAccessBase(BaseSchema):
+    user_id: int
+    property_id: int
+    access_level: AccessLevel
+    expires_at: Optional[datetime] = None
+
+class UserPropertyAccessCreate(UserPropertyAccessBase):
+    pass
+
+class UserPropertyAccessUpdate(BaseSchema):
+    access_level: Optional[AccessLevel] = None
+    expires_at: Optional[datetime] = None
+
+class UserPropertyAccess(UserPropertyAccessBase):
+    granted_at: datetime
+    user: Optional[UserSummary] = None
+    property: Optional[Property] = None
+```
+
+### Machine-Procedure Schemas
+
+```python
+class MachineWithProcedures(BaseSchema):
+    id: int
+    room_id: int
+    name: str
+    model: Optional[str]
+    serial_number: str
+    description: Optional[str]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    room: Optional[Room] = None
+    procedures: List[Procedure] = []
+
+class ProcedureWithMachines(BaseSchema):
+    id: int
+    topic_id: int
+    title: str
+    description: Optional[str]
+    instructions: Optional[str]
+    estimated_minutes: Optional[int]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    topic: Optional[Topic] = None
+    machines: List[MachineSummary] = []
+
+class ProcedureCreate(ProcedureBase):
+    machine_ids: Optional[List[int]] = []  # Optional list of machine IDs to associate
+
+class ProcedureUpdate(BaseSchema):
+    title: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=1000)
+    instructions: Optional[str] = Field(None, max_length=5000)
+    estimated_minutes: Optional[int] = Field(None, ge=1, le=1440)
+    is_active: Optional[bool] = None
+    machine_ids: Optional[List[int]] = None  # Optional list of machine IDs to update associations
+```
+
+## Database Indexes
+
+### UserPropertyAccess Indexes
+
+```sql
+CREATE INDEX idx_user_property_access_level ON user_property_access (access_level, user_id);
+CREATE INDEX idx_user_property_expires ON user_property_access (expires_at, user_id);
+CREATE INDEX idx_property_access_granted ON user_property_access (granted_at, property_id);
+```
+
+### Machine-Procedure Association Indexes
+
+```sql
+CREATE INDEX idx_machine_procedure_machine ON machine_procedure_association (machine_id);
+CREATE INDEX idx_machine_procedure_procedure ON machine_procedure_association (procedure_id);
+```
+
+## API Usage Examples
+
+### User Property Access
+
+```python
+# Grant user access to property
+user_access = UserPropertyAccessCreate(
+    user_id=1,
+    property_id=2,
+    access_level=AccessLevel.FULL_ACCESS,
+    expires_at=datetime.now() + timedelta(days=30)
+)
+
+# Get all properties a user has access to
+user_properties = await get_user_properties(user_id=1)
+
+# Get all users with access to a property
+property_users = await get_property_users(property_id=2)
+```
+
+### Machine-Procedure Association
+
+```python
+# Create procedure with machine associations
+procedure = ProcedureCreate(
+    topic_id=1,
+    title="HVAC Filter Replacement",
+    description="Monthly filter replacement procedure",
+    estimated_minutes=30,
+    machine_ids=[1, 2, 3]  # Associate with multiple machines
+)
+
+# Update procedure machine associations
+procedure_update = ProcedureUpdate(
+    title="Updated HVAC Filter Replacement",
+    machine_ids=[1, 2, 4]  # Update associations
+)
+
+# Get machines with their procedures
+machines_with_procedures = await get_machines_with_procedures()
+
+# Get procedures for a specific machine
+machine_procedures = await get_procedures_for_machine(machine_id=1)
+```
+
+## Migration Notes
+
+### Adding Machine-Procedure Association
+
+A new migration has been created: `899398de0caf_add_machine_procedure_association.py`
+
+To apply the migration:
+```bash
+alembic upgrade head
+```
+
+### Data Migration Considerations
+
+After applying the migration, you may want to:
+1. Populate the machine_procedure_association table with existing relationships
+2. Update existing PMSchedule records to ensure they reference valid machine-procedure combinations
+3. Add validation in your application to enforce these relationships
+
+## Security Considerations
+
+### User Property Access
+
+1. **Principle of Least Privilege**: Users should only have the minimum access level required
+2. **Time-Limited Access**: Use expires_at for temporary access grants
+3. **Audit Trail**: The granted_at field provides an audit trail of access grants
+4. **Access Level Hierarchy**: Implement proper access level checks in your application logic
+
+### Machine-Procedure Associations
+
+1. **Validation**: Always validate machine-procedure combinations before creating PM schedules
+2. **Data Integrity**: Use foreign key constraints to ensure referential integrity
+3. **Business Logic**: Implement business rules for which procedures can be assigned to which machines
+
+## Performance Considerations
+
+1. **Lazy Loading**: Both relationships use `lazy="selectin"` for efficient loading
+2. **Indexes**: Comprehensive indexing on foreign keys and commonly queried columns
+3. **Caching**: Consider caching user property access for frequently accessed data
+4. **Pagination**: Use pagination for endpoints that return large datasets
+
+## Future Enhancements
+
+1. **User Groups**: Consider adding user groups for easier property access management
+2. **Property Hierarchies**: Support for property hierarchies (buildings, floors, units)
+3. **Procedure Versioning**: Version control for procedures
+4. **Access Logging**: Log access attempts and actions for compliance

--- a/backend/alembic/versions/899398de0caf_add_machine_procedure_association.py
+++ b/backend/alembic/versions/899398de0caf_add_machine_procedure_association.py
@@ -1,0 +1,46 @@
+"""Add machine_procedure_association table
+
+Revision ID: 899398de0caf
+Revises: 17f8bad509d5
+Create Date: 2025-01-10 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '899398de0caf'
+down_revision: Union[str, Sequence[str], None] = '17f8bad509d5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add machine_procedure_association table for many-to-many relationship."""
+    # Create the machine_procedure_association table
+    op.create_table(
+        'machine_procedure_association',
+        sa.Column('machine_id', sa.Integer(), nullable=False),
+        sa.Column('procedure_id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['machine_id'], ['machines.id'], ),
+        sa.ForeignKeyConstraint(['procedure_id'], ['procedures.id'], ),
+        sa.PrimaryKeyConstraint('machine_id', 'procedure_id')
+    )
+    
+    # Create indexes
+    op.create_index('idx_machine_procedure_machine', 'machine_procedure_association', ['machine_id'])
+    op.create_index('idx_machine_procedure_procedure', 'machine_procedure_association', ['procedure_id'])
+
+
+def downgrade() -> None:
+    """Remove machine_procedure_association table."""
+    # Drop indexes
+    op.drop_index('idx_machine_procedure_procedure', 'machine_procedure_association')
+    op.drop_index('idx_machine_procedure_machine', 'machine_procedure_association')
+    
+    # Drop table
+    op.drop_table('machine_procedure_association')

--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -3,7 +3,7 @@
 """
 SQLAlchemy models for PM System
 """
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, ForeignKey, Text, Index
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, ForeignKey, Text, Index, Table
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import enum
@@ -11,6 +11,17 @@ from datetime import datetime
 
 # Import Base from database with absolute import
 from database import Base
+
+# Association table for many-to-many relationship between machines and procedures
+machine_procedure_association = Table(
+    'machine_procedure_association',
+    Base.metadata,
+    Column('machine_id', Integer, ForeignKey('machines.id'), primary_key=True),
+    Column('procedure_id', Integer, ForeignKey('procedures.id'), primary_key=True),
+    Column('created_at', DateTime, server_default=func.now()),
+    Index('idx_machine_procedure_machine', 'machine_id'),
+    Index('idx_machine_procedure_procedure', 'procedure_id'),
+)
 
 # Enums
 class UserRole(str, enum.Enum):
@@ -152,6 +163,7 @@ class Machine(Base):
     pm_schedules = relationship("PMSchedule", back_populates="machine", lazy="selectin")
     issues = relationship("Issue", back_populates="machine", lazy="selectin")
     inspections = relationship("Inspection", back_populates="machine", lazy="selectin")
+    procedures = relationship("Procedure", secondary=machine_procedure_association, back_populates="machines", lazy="selectin")
     
     # Indexes
     __table_args__ = (
@@ -195,6 +207,7 @@ class Procedure(Base):
     topic = relationship("Topic", back_populates="procedures", lazy="selectin")
     pm_schedules = relationship("PMSchedule", back_populates="procedure", lazy="selectin")
     inspections = relationship("Inspection", back_populates="procedure", lazy="selectin")
+    machines = relationship("Machine", secondary=machine_procedure_association, back_populates="procedures", lazy="selectin")
     
     # Indexes
     __table_args__ = (

--- a/backend/my_app/schemas.py
+++ b/backend/my_app/schemas.py
@@ -173,7 +173,7 @@ class ProcedureBase(BaseSchema):
     is_active: bool = True
 
 class ProcedureCreate(ProcedureBase):
-    pass
+    machine_ids: Optional[List[int]] = []  # Optional list of machine IDs to associate
 
 class ProcedureUpdate(BaseSchema):
     title: Optional[str] = Field(None, min_length=1, max_length=100)
@@ -181,12 +181,40 @@ class ProcedureUpdate(BaseSchema):
     instructions: Optional[str] = Field(None, max_length=5000)
     estimated_minutes: Optional[int] = Field(None, ge=1, le=1440)
     is_active: Optional[bool] = None
+    machine_ids: Optional[List[int]] = None  # Optional list of machine IDs to update associations
 
 class Procedure(ProcedureBase):
     id: int
     created_at: datetime
     updated_at: datetime
     topic: Optional[Topic] = None
+
+# Machine-Procedure Many-to-Many Schemas
+class MachineWithProcedures(BaseSchema):
+    id: int
+    room_id: int
+    name: str
+    model: Optional[str]
+    serial_number: str
+    description: Optional[str]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    room: Optional[Room] = None
+    procedures: List[Procedure] = []
+
+class ProcedureWithMachines(BaseSchema):
+    id: int
+    topic_id: int
+    title: str
+    description: Optional[str]
+    instructions: Optional[str]
+    estimated_minutes: Optional[int]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    topic: Optional[Topic] = None
+    machines: List[MachineSummary] = []
 
 # PM Schedule Schemas
 class PMScheduleBase(BaseSchema):


### PR DESCRIPTION
<!-- Implement missing Machine-Procedure many-to-many relationship and document the overall schema. -->

The existing codebase referenced a `machine_procedure_association` table and related Pydantic schemas (`MachineWithProcedures`, `ProcedureWithMachines`) that were not defined, leading to an incomplete schema for the PM system. This PR addresses this by adding the necessary SQLAlchemy association table, updating the models, creating the Pydantic schemas, and generating a database migration. It also includes a comprehensive `SCHEMA_DOCUMENTATION.md` file to explain all key relationships, including the existing User-Property many-to-many.

---

[Open in Web](https://www.cursor.com/agents?id=bc-07daa77e-59c7-49c3-9110-a73b0f5cc641) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-07daa77e-59c7-49c3-9110-a73b0f5cc641)