### PR TITLE
Continue bc-f19e710e-c949-47ff-84fb-b82f64c929b6 operation

### DIFF
--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -10,7 +10,7 @@ import enum
 from datetime import datetime
 
 # Import Base from database with absolute import
-from database import Base
+from .database import Base
 
 # Association table for many-to-many relationship between machines and procedures
 machine_procedure_association = Table(

--- a/backend/my_app/schemas.py
+++ b/backend/my_app/schemas.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from enum import Enum
 
 # Import enums from models
-from models import (
+from .models import (
     UserRole, FrequencyType, PMStatus, IssueStatus, IssuePriority,
     InspectionResult, ImageType, AccessLevel, WorkOrderType, WorkOrderStatus
 )

--- a/frontend/my_job/src/components/forms/CreateWorkOrderForm.tsx
+++ b/frontend/my_job/src/components/forms/CreateWorkOrderForm.tsx
@@ -32,6 +32,7 @@ const initialFormData = {
   status: 'Pending',
   type: 'pm',
   topic_id: '',
+  topic_ids: [],  // Array for many-to-many topics relationship
   has_pm: false,
   has_issue: false,
   beforePhotos: [],
@@ -519,6 +520,7 @@ export function CreateWorkOrderForm() {
         property_id: numericPropertyId as number,
         type: allowedTypes.includes(formData.type as AllowedType) ? (formData.type as AllowedType) : 'pm',
         topic_id: formData.topic_id ? Number(formData.topic_id) : undefined,
+        topic_ids: Array.isArray(formData.topic_ids) ? formData.topic_ids.map(id => Number(id)) : undefined,
         has_pm: formData.type === 'pm' ? true : false,
         has_issue: !!formData.has_issue,
         frequency: (formData.type === 'pm' && formData.frequency) ? formData.frequency : undefined,
@@ -608,6 +610,14 @@ export function CreateWorkOrderForm() {
           { value: '', label: 'No Topic Selected' },
           ...topics.map((topic) => ({ value: topic.id.toString(), label: topic.title })),
         ]
+      case 'topic_ids':
+        if (topicsLoading) {
+          return [{ value: '', label: 'Loading topics...' }]
+        }
+        if (topicsError) {
+          return [{ value: '', label: 'Failed to load topics' }]
+        }
+        return topics.map((topic) => ({ value: topic.id.toString(), label: topic.title }))
       case 'frequency':
         return [
           { value: '', label: 'Select Frequency' },

--- a/frontend/my_job/src/components/forms/dynamic-form-renderer.tsx
+++ b/frontend/my_job/src/components/forms/dynamic-form-renderer.tsx
@@ -115,6 +115,35 @@ export function DynamicFormRenderer({
           </div>
         )
 
+      case 'enhanced-checkbox':
+        const checkboxOptions = field.options || selectOptions
+        const selectedValues = Array.isArray(value) ? value : []
+        
+        return (
+          <div className="space-y-2">
+            {checkboxOptions.map((option) => (
+              <div key={option.value} className="flex items-center">
+                <input
+                  type="checkbox"
+                  id={`${field.name}-${option.value}`}
+                  checked={selectedValues.includes(option.value)}
+                  onChange={(e) => {
+                    const newValues = e.target.checked
+                      ? [...selectedValues, option.value]
+                      : selectedValues.filter(v => v !== option.value)
+                    onChange(newValues)
+                  }}
+                  onBlur={onBlur}
+                  className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                />
+                <label htmlFor={`${field.name}-${option.value}`} className="text-sm text-gray-700">
+                  {option.label}
+                </label>
+              </div>
+            ))}
+          </div>
+        )
+
       case 'datetime-local':
       case 'date':
         return (

--- a/frontend/my_job/src/config/work-order-form-config.ts
+++ b/frontend/my_job/src/config/work-order-form-config.ts
@@ -142,9 +142,16 @@ export const workOrderFormSections: FormSection[] = [
       },
       {
         name: 'topic_id',
-        label: 'Topic Category (Optional)',
+        label: 'Primary Topic Category (Optional)',
         type: 'select',
         required: false,
+      },
+      {
+        name: 'topic_ids',
+        label: 'Related Topics (Optional)',
+        type: 'enhanced-checkbox',
+        required: false,
+        description: 'Select all topics that relate to this work order',
       },
     ],
   },

--- a/frontend/my_job/src/services/work-orders-api.ts
+++ b/frontend/my_job/src/services/work-orders-api.ts
@@ -21,6 +21,7 @@ export interface WorkOrder {
   pdf_file_path: string | null
   type: 'pm' | 'issue' | 'workorder'
   topic_id: number | null
+  topics?: Array<{id: number, title: string}>  // Many-to-many topics relationship
 }
 
 export interface CreateWorkOrderData {
@@ -39,6 +40,7 @@ export interface CreateWorkOrderData {
   pdf_file_path?: string | null
   type: 'pm' | 'issue' | 'workorder'
   topic_id?: number | null
+  topic_ids?: number[]  // Many-to-many topics relationship
   procedure_id?: number | null
   frequency?: string | null
 }


### PR DESCRIPTION
Add many-to-many topic relationship support to WorkOrder frontend to enable flexible categorization.

The backend already supported associating work orders with multiple topics via `topic_ids`, but the frontend form and API interface were not updated to utilize this functionality. This PR completes the frontend implementation, allowing users to select multiple topics for a work order.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c35a1d8d-c173-4a2e-98d2-d694323fcc07) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c35a1d8d-c173-4a2e-98d2-d694323fcc07)