### PR TITLE
Fix float type error in models

### DIFF
--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -3,7 +3,7 @@
 """
 SQLAlchemy models for PM System
 """
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, ForeignKey, Text, Index, Table
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, ForeignKey, Text, Index, Table, Float
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import enum


### PR DESCRIPTION
Import `Float` from SQLAlchemy to resolve `NameError` in `models.py`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5b2c85eb-1208-42c8-a1e8-5615dec71233) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5b2c85eb-1208-42c8-a1e8-5615dec71233)