### PR TITLE
Fix missing work orders title column

### DIFF
--- a/backend/DATABASE_MIGRATION_FIX.md
+++ b/backend/DATABASE_MIGRATION_FIX.md
@@ -1,0 +1,115 @@
+# Database Migration Fix for Missing `title` Column
+
+## Problem Description
+
+The application is failing with the following error:
+```
+psycopg2.errors.UndefinedColumn: column work_orders.title does not exist
+```
+
+This error occurs because the SQLAlchemy model defines a `title` column in the `WorkOrder` model, but this column doesn't exist in the actual database table. The migration that adds this column exists but hasn't been applied to the database.
+
+## Root Cause
+
+The migration file `2a3b4c5d6e7f_add_enhanced_work_order_fields.py` exists and includes the `title` column addition, but it hasn't been applied to the database. This creates a mismatch between the model definition and the actual database schema.
+
+## Solutions
+
+### Solution 1: Run Migration via Docker (Recommended)
+
+If you're using Docker, run the migration from within the backend container:
+
+```bash
+# Enter the backend container
+docker exec -it <backend_container_name> bash
+
+# Run the migration
+cd /app
+alembic upgrade head
+```
+
+### Solution 2: Run Migration via Docker Compose
+
+```bash
+# From the project root directory
+docker-compose exec backend alembic upgrade head
+```
+
+### Solution 3: Manual SQL Script
+
+If you can't run Alembic migrations, execute the SQL script directly on the database:
+
+```bash
+# Connect to PostgreSQL and run the SQL script
+docker exec -it <postgres_container_name> psql -U postgres -d fullstack_db -f /path/to/add_title_column.sql
+```
+
+Or copy the SQL script to the container first:
+```bash
+docker cp add_title_column.sql <postgres_container_name>:/tmp/
+docker exec -it <postgres_container_name> psql -U postgres -d fullstack_db -f /tmp/add_title_column.sql
+```
+
+### Solution 4: Direct Database Connection
+
+If you have direct access to the PostgreSQL database:
+
+```bash
+psql -h <database_host> -U postgres -d fullstack_db -f add_title_column.sql
+```
+
+## Files Created
+
+1. **`add_title_column.sql`** - SQL script that safely adds all missing columns
+2. **`run_migration_localhost.py`** - Python script to run migrations (for local development)
+3. **`DATABASE_MIGRATION_FIX.md`** - This documentation
+
+## What the Migration Adds
+
+The migration adds the following columns to the `work_orders` table:
+
+- `title` VARCHAR(100) - Job title
+- `estimated_duration` INTEGER - Duration in minutes  
+- `safety_requirements` TEXT - Safety requirements and PPE
+- `required_tools` TEXT - Required tools and equipment
+- `required_parts` TEXT - Required parts and materials
+- `special_instructions` TEXT - Special instructions and notes
+- `cost_estimate` FLOAT - Estimated cost
+
+It also makes the following columns nullable:
+- `machine_id` - For general work orders not tied to specific machines
+- `priority` - For general work orders without priority
+
+## Verification
+
+After running the migration, verify it worked by checking the database schema:
+
+```sql
+-- Check if the title column exists
+SELECT column_name, data_type, is_nullable 
+FROM information_schema.columns 
+WHERE table_name = 'work_orders' 
+AND column_name = 'title';
+
+-- Check all columns in work_orders table
+\d work_orders
+```
+
+## Prevention
+
+To prevent this issue in the future:
+
+1. Always run migrations after pulling code changes
+2. Use `alembic current` to check migration status
+3. Use `alembic history` to see available migrations
+4. Set up automated migration checks in your deployment process
+
+## Quick Fix Command
+
+For Docker environments, the quickest fix is usually:
+
+```bash
+docker-compose exec backend alembic upgrade head
+```
+
+This will apply all pending migrations to bring the database schema up to date with the model definitions.

--- a/backend/add_title_column.sql
+++ b/backend/add_title_column.sql
@@ -1,0 +1,120 @@
+-- Add title column to work_orders table if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'title'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN title VARCHAR(100);
+        CREATE INDEX ix_work_orders_title ON work_orders (title);
+        RAISE NOTICE 'Added title column to work_orders table';
+    ELSE
+        RAISE NOTICE 'Title column already exists in work_orders table';
+    END IF;
+END $$;
+
+-- Add estimated_duration column if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'estimated_duration'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN estimated_duration INTEGER;
+        CREATE INDEX ix_work_orders_estimated_duration ON work_orders (estimated_duration);
+        RAISE NOTICE 'Added estimated_duration column to work_orders table';
+    ELSE
+        RAISE NOTICE 'Estimated_duration column already exists in work_orders table';
+    END IF;
+END $$;
+
+-- Add other enhanced fields if they don't exist
+DO $$
+BEGIN
+    -- safety_requirements
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'safety_requirements'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN safety_requirements TEXT;
+        RAISE NOTICE 'Added safety_requirements column to work_orders table';
+    END IF;
+    
+    -- required_tools
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'required_tools'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN required_tools TEXT;
+        RAISE NOTICE 'Added required_tools column to work_orders table';
+    END IF;
+    
+    -- required_parts
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'required_parts'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN required_parts TEXT;
+        RAISE NOTICE 'Added required_parts column to work_orders table';
+    END IF;
+    
+    -- special_instructions
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'special_instructions'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN special_instructions TEXT;
+        RAISE NOTICE 'Added special_instructions column to work_orders table';
+    END IF;
+    
+    -- cost_estimate
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'cost_estimate'
+    ) THEN
+        ALTER TABLE work_orders ADD COLUMN cost_estimate FLOAT;
+        RAISE NOTICE 'Added cost_estimate column to work_orders table';
+    END IF;
+END $$;
+
+-- Make machine_id and priority nullable if they aren't already
+DO $$
+BEGIN
+    -- Check if machine_id is nullable
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'machine_id'
+        AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE work_orders ALTER COLUMN machine_id DROP NOT NULL;
+        RAISE NOTICE 'Made machine_id column nullable in work_orders table';
+    END IF;
+    
+    -- Check if priority is nullable
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'work_orders' 
+        AND column_name = 'priority'
+        AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE work_orders ALTER COLUMN priority DROP NOT NULL;
+        RAISE NOTICE 'Made priority column nullable in work_orders table';
+    END IF;
+END $$;

--- a/backend/my_app/models.py
+++ b/backend/my_app/models.py
@@ -10,7 +10,7 @@ import enum
 from datetime import datetime
 
 # Import Base from database with absolute import
-from database import Base
+from my_app.database import Base
 
 # Association table for many-to-many relationship between machines and procedures
 machine_procedure_association = Table(

--- a/backend/run_migration_localhost.py
+++ b/backend/run_migration_localhost.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Script to run database migrations using localhost connection
+"""
+import os
+import sys
+from pathlib import Path
+
+# Add the current directory to Python path
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Set environment variables to use localhost
+os.environ['DB_NAME'] = 'fullstack_db'
+os.environ['DB_USER'] = 'postgres'
+os.environ['DB_PASSWORD'] = 'postgres'
+os.environ['DB_HOST'] = 'localhost'
+os.environ['DB_PORT'] = '5432'
+
+# Try different hosts if localhost doesn't work
+hosts_to_try = ['localhost', '127.0.0.1', 'db']
+
+def try_connection_with_host(host):
+    """Try to connect to database with given host"""
+    os.environ['DB_HOST'] = host
+    try:
+        from alembic.config import Config
+        from alembic import command
+        
+        # Get the directory containing this script
+        script_dir = Path(__file__).parent
+        alembic_ini_path = script_dir / "alembic.ini"
+        
+        print(f"Trying connection to host: {host}")
+        print(f"Using alembic.ini at: {alembic_ini_path}")
+        
+        # Create alembic configuration
+        alembic_cfg = Config(str(alembic_ini_path))
+        
+        # Override the database URL in the config
+        db_url = f"postgresql://postgres:postgres@{host}:5432/fullstack_db"
+        alembic_cfg.set_main_option('sqlalchemy.url', db_url)
+        
+        # Check current migration
+        print("Current migration status:")
+        command.current(alembic_cfg)
+        
+        # Run migrations
+        print("\nRunning migrations...")
+        command.upgrade(alembic_cfg, "head")
+        
+        print(f"Migration completed successfully using host: {host}!")
+        return True
+        
+    except Exception as e:
+        print(f"Failed to connect to host {host}: {e}")
+        return False
+
+# Try each host until one works
+success = False
+for host in hosts_to_try:
+    if try_connection_with_host(host):
+        success = True
+        break
+
+if not success:
+    print("Failed to connect to database with any host. Please ensure PostgreSQL is running and accessible.")
+    print("\nAlternatively, you can run the SQL script manually:")
+    print("psql -h localhost -U postgres -d fullstack_db -f add_title_column.sql")
+    sys.exit(1)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolve `UndefinedColumn` error for `work_orders.title` by applying schema updates and fixing migration setup.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application crashed because the `WorkOrder` model expected a `title` column that was missing from the database. Although a migration existed, it wasn't applied due to an incorrect import path in `models.py` and environmental challenges in running Alembic. This PR fixes the import, provides a direct SQL script, and comprehensive instructions to bring the database schema in sync.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c524b8bf-03eb-4916-8027-c0edbe196e38) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c524b8bf-03eb-4916-8027-c0edbe196e38)